### PR TITLE
LUGG-841 - Search bar should be a block

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -513,7 +513,6 @@ input[type="email"],
 input[type="month"],
 input[type="number"],
 input[type="password"],
-input[type="search"],
 input[type="tel"],
 input[type="text"],
 input[type="time"],
@@ -580,36 +579,65 @@ input[type="submit"] {
     position: relative;
 }
 
-.region-search-inner .search-form-container {
+.region-search-inner input[type="submit"],
+.region-search-inner input[type="submit"]:focus {
+    background: url(../images/search_gray.png) no-repeat 0 center;
+    background-size: contain;
+    -webkit-box-shadow: none;
+    -mox-box-shadow: none;
+    box-shadow: none;
+    border: none;
+    margin: 0px 0px 0px 20px;
+}
+
+.region-search-inner input[type=text],
+.region-search-inner input[type=text]:focus,
+.region-search-inner textarea:focus {
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
+    border: none;
+}
+
+#search-block-form {
     border-radius: 2px;
     width: 100%;
-    max-width: 400px;
+    max-width: 800px;
     background-color: #fff;
 }
 
-.region-search-inner .search-form-container.has-site-name-level-2 {
+.page-search input#edit-keys,
+.page form#search-block-form .form-item-search-block-form input.form-text {
+    width: calc(100% - 62px);
+}
+
+.region-search-inner .block-search .block-title {
+    color: white;
+}
+
+.region-search-inner .block-search-form.has-site-name-level-2 {
     margin-top: 6px;
 }
 
-.region-search-inner .search-form-container.has-site-name-level-3 {
+.region-search-inner .block-search-form.has-site-name-level-3 {
     margin-top: 24px;
 }
 
-.region-search .search-form {
+.region-search .block-search-form {
     margin-bottom: 0;
 }
 
-.region-search .search-form .form-wrapper {
+.region-search .block-search-form .form-wrapper {
     position: relative;
 }
 
-.region-search .search-form .form-text {
+.region-search .block-search-form .form-text {
     font-size: 16px;
     padding: 8px 10px;
     height: 100%;
 }
 
-.region-search .search-form .form-text:not(.throbbing) {
+.region-search .block-search-form .form-text:not(.throbbing) {
     background-image: none;
 }
 
@@ -1784,11 +1812,6 @@ html.js input.form-autocomplete {
 
 .item-list a:hover {
     text-decoration: underline;
-}
-
-.page-search .search-form input#edit-submit:hover,
-.page form#search-block-form .form-actions input.form-submit:hover {
-    border: 1px solid #F1BE48;
 }
 
 /*.block-apachesolr-search:hover {*/

--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -602,8 +602,16 @@ input[type="submit"] {
 #search-block-form {
     border-radius: 2px;
     width: 100%;
-    max-width: 800px;
     background-color: #fff;
+    min-width: 400px;
+}
+
+@media all and (max-width: 900px) {
+    #search-block-form { min-width: 200px; }
+}
+
+.region-search-inner .block-search-form {
+    margin-top: 1.5em;
 }
 
 .page-search input#edit-keys,

--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -610,8 +610,12 @@ input[type="submit"] {
     #search-block-form { min-width: 200px; }
 }
 
-.region-search-inner .block-search-form {
-    margin-top: 1.5em;
+.region-search-inner .search-form-container.has-site-name-level-2 {
+    margin-top: 6px;
+}
+
+.region-search-inner .search-form-container.has-site-name-level-3 {
+    margin-top: 24px;
 }
 
 .page-search input#edit-keys,

--- a/template.php
+++ b/template.php
@@ -107,3 +107,10 @@ function suitcase_interim_preprocess_content(&$vars) {
 function suitcase_interim_facetapi_deactivate_widget($variables) {
   return '&nbsp;&times;';
 }
+
+function suitcase_interim_form_alter(&$form, &$form_state, $form_id) {
+  if ($form_id == 'search_block_form') {
+    $form['actions']['submit']['#value'] = '  ';
+  }
+}
+

--- a/template.php
+++ b/template.php
@@ -76,19 +76,6 @@ function suitcase_interim_preprocess_region(&$vars) {
     $vars['site_name'] = variable_get('site_name');
     $vars['linked_site_name'] = l($vars['site_name'], '<front>', array('attributes' => array('title' => t('Home')), 'html' => TRUE));
   } else if($vars['region'] == 'search') {
-    $search_form = drupal_get_form('search_block_form');
-    // Hide the input label
-   $search_form['search_block_form']['#title_display'] = 'invisible';
-   $search_form['search_block_form']['#attributes']['placeholder'] = t('Search');
-   $search_form['search_block_form']['#attributes']['class'][] = 'transparent';
-   $search_form['actions']['submit'] = array(
-     '#type' => 'item',
-     '#markup' => '<button type="submit" id="edit-submit" name="op" class="form-submit transparent"><img src="' . base_path() . drupal_get_path('theme', 'suitcase_interim') . '/images/search_gray.png" class="img-responsive" alt="Search" height="24px"></button>',
-   );
-    $search_form['#form_id'] = 'apachesolr_search_custom_page_search_form';
-    $search_form_box = drupal_render($search_form);
-    $vars['search_form'] = $search_form_box;
-
     // Load the categories vocabulary
     $vars['categories'] = taxonomy_get_tree(1);
 

--- a/templates/region--search.tpl.php
+++ b/templates/region--search.tpl.php
@@ -1,14 +1,11 @@
 <div<?php print $attributes; ?>>
   <div<?php print $content_attributes; ?>>
+    <?php if ($content): ?>
     <div class="clearfix">
       <?php $site_name_level_2_class = ($suitcase_interim_config_header_type < 3) ? ' has-site-name-level-2' : ''; ?>
       <?php $site_name_level_3_class = ($suitcase_interim_config_header_type == 1 || $suitcase_interim_config_header_type == 3 || $suitcase_interim_config_header_type == 4) ? ' has-site-name-level-3' : ''; ?>
-      <div class="pull-right margin-left-10 pos-relative search-form-container<?php print $site_name_level_2_class . $site_name_level_3_class; ?>"></div>
+        <div class="pull-right margin-left-10 pos-relative search-form-container<?php print $site_name_level_2_class . $site_name_level_3_class; ?>"><?php print $content; ?></div>
     </div>
-    <?php if ($content): ?>
-      <div class="clearfix">
-        <div class="pull-right"><?php print $content; ?></div>
-      </div>
     <?php endif; ?>
   </div>
 </div>

--- a/templates/region--search.tpl.php
+++ b/templates/region--search.tpl.php
@@ -3,18 +3,7 @@
     <div class="clearfix">
       <?php $site_name_level_2_class = ($suitcase_interim_config_header_type < 3) ? ' has-site-name-level-2' : ''; ?>
       <?php $site_name_level_3_class = ($suitcase_interim_config_header_type == 1 || $suitcase_interim_config_header_type == 3 || $suitcase_interim_config_header_type == 4) ? ' has-site-name-level-3' : ''; ?>
-      <div class="pull-right margin-left-10 pos-relative search-form-container<?php print $site_name_level_2_class . $site_name_level_3_class; ?>">
-        <?php print $search_form; ?>
-        <div class="popover">
-          <div class="arrow"></div>
-          <h3>Popular searches:</h3>
-          <ul class="menu">
-            <?php foreach ($categories as $term): ?>
-            <li><a href="<?php print taxonomy_term_uri($term)['path']; ?>"><?php print $term->name; ?></a></li>
-            <?php endforeach; ?>
-          </ul>
-        </div>
-      </div>
+      <div class="pull-right margin-left-10 pos-relative search-form-container<?php print $site_name_level_2_class . $site_name_level_3_class; ?>"></div>
     </div>
     <?php if ($content): ?>
       <div class="clearfix">


### PR DESCRIPTION
## Need

Currently, the search bar is hard coded into template.php. This means sites that don't use search or want to use some other search option have to use the solr search regardless.
## Implementation

I removed the search bar from template.php and from region--search.tpl.php. I re-added the button by using the background property in CSS.
## Testing

I tested this on a local copy of the suitcase_luggage site.
- Pull down my changes
- Clear caches, etc.
- Add the "Search form" block to the "Search" region
- Go to the home page. Is the search form there?
- Add a site name/department name (so the header has 3 levels). Is there enough padding above the search bar?
- Only have the site name. Is there too much padding above the search bar?
- Double-check to see if the form is responsive.
- Does the search bar work?
