### PR TITLE
Mark menu items active if absolute url matches

### DIFF
--- a/template.php
+++ b/template.php
@@ -138,7 +138,11 @@ function suitcase_interim_alpha_preprocess_region(&$vars) {
 /* Menu List Theme Functions */
 
 /*
- * Clone of theme_links that also adds the active classes for query string matches
+ * Clone of theme_links that also adds the active classes for absolute url
+ * matches (including query string). This does not handle the case, which might
+ * be considered a core bug, where multiple menu items that link to the same
+ * page and differ only in query strings will both highlight upon visiting
+ * either of them.
  */
 function suitcase_interim_menu_links($variables)  {
 

--- a/template.php
+++ b/template.php
@@ -134,3 +134,103 @@ function suitcase_interim_alpha_preprocess_region(&$vars) {
     unset($vars['elements']['#grid_container']);
   }
 }
+
+/* Menu List Theme Functions */
+
+/*
+ * Clone of theme_links that also adds the active classes for query string matches
+ */
+function suitcase_interim_menu_links($variables)  {
+
+  $links = $variables['links'];
+  $attributes = $variables['attributes'];
+  $heading = $variables['heading'];
+  global $language_url;
+  $output = '';
+
+  if (count($links) > 0) {
+    // Treat the heading first if it is present to prepend it to the
+    // list of links.
+    if (!empty($heading)) {
+      if (is_string($heading)) {
+        // Prepare the array that will be used when the passed heading
+        // is a string.
+        $heading = array(
+          'text' => $heading,
+          // Set the default level of the heading.
+          'level' => 'h2',
+        );
+      }
+      $output .= '<' . $heading['level'];
+      if (!empty($heading['class'])) {
+        $output .= drupal_attributes(array('class' => $heading['class']));
+      }
+      $output .= '>' . check_plain($heading['text']) . '</' . $heading['level'] . '>';
+    }
+
+    $output .= '<ul' . drupal_attributes($attributes) . '>';
+
+    $num_links = count($links);
+    $i = 1;
+
+    foreach ($links as $key => $link) {
+      $class = array($key);
+
+      // Add first, last and active classes to the list of links to help out
+      // themers.
+      if ($i == 1) {
+        $class[] = 'first';
+      }
+      if ($i == $num_links) {
+        $class[] = 'last';
+      }
+      if (isset($link['href']) && (($link['href'] == $_GET['q'] || $link['href'] == ($GLOBALS['base_root'] . request_uri())) || ($link['href'] == '<front>' && drupal_is_front_page()))
+        && (empty($link['language']) || $link['language']->language == $language_url->language)) {
+        $class[] = 'active';
+        $class[] = 'active-trail';
+        $link['attributes']['class'][] = 'active';
+        $link['attributes']['class'][] = 'active-trail';
+      }
+      $output .= '<li' . drupal_attributes(array('class' => $class)) . '>';
+
+      if (isset($link['href'])) {
+        // Pass in $link as $options, they share the same keys.
+        $output .= l($link['title'], $link['href'], $link);
+      }
+      elseif (!empty($link['title'])) {
+        // Some links are actually not links, but we wrap these in <span> for
+        // adding title and class attributes.
+        if (empty($link['html'])) {
+          $link['title'] = check_plain($link['title']);
+        }
+        $span_attributes = '';
+        if (isset($link['attributes'])) {
+          $span_attributes = drupal_attributes($link['attributes']);
+        }
+        $output .= '<span' . $span_attributes . '>' . $link['title'] . '</span>';
+      }
+
+      $i++;
+      $output .= "</li>\n";
+    }
+
+    $output .= '</ul>';
+  }
+
+  return $output;
+
+}
+
+/*
+ * Implements theme_links__system_main_menu()
+ */
+function suitcase_interim_links__system_main_menu($variables) {
+  return suitcase_interim_menu_links($variables);
+}
+
+/*
+ * Implements theme_links__system_secondary_menu()
+ */
+function suitcase_interim_links__system_secondary_menu($variables) {
+  return suitcase_interim_menu_links($variables);
+}


### PR DESCRIPTION
By default, Drupal will not mark menu items as active based on an absolute match of the page URL.

This is a problem when menu items are created with absolute URLs paths in order to preserve query strings.

This pull requests provides implementations of theme_links__system_main_menu and suitcase_interim_links__system_secondary_menu that will also mark an menu item as active if the menu link matches the full URL of the current page.