### PR TITLE
LUGG 914 - Fixed secondary nav link wrapping, cleaned up text-align

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1633,7 +1633,7 @@ figure .insert-default-image-styling + figcaption {
 .region-secondary-menu .links > li {
     padding: 0;
     margin-right: 0;
-    white-space: nowrap;
+
 }
 
 .region-secondary-menu .links > li > a {
@@ -1643,6 +1643,7 @@ figure .insert-default-image-styling + figcaption {
     font-weight: 500;
     text-decoration: none;
     border-bottom: none;
+        white-space: nowrap;
     transition: background-color 0.5s ease;
 }
 

--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1643,7 +1643,7 @@ figure .insert-default-image-styling + figcaption {
     font-weight: 500;
     text-decoration: none;
     border-bottom: none;
-        white-space: nowrap;
+    white-space: nowrap;
     transition: background-color 0.5s ease;
 }
 

--- a/css/suitcase_responsive.css
+++ b/css/suitcase_responsive.css
@@ -172,7 +172,6 @@
         height: 1em;
     }
 
-    .region-secondary-menu { text-align: left; }
 }
 
 @media print {


### PR DESCRIPTION
Fixed links not wrapping, removed redundant text-align on mobile. Wasn’t allowed to make another branch with the same name as LUGG-914