### PR TITLE
LUGG 918 - Lined up padding on homepage panels

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1142,6 +1142,10 @@ nav.navigation .secondary-menu>li a.active-trail {
 
 .panel-panel .pane-content { margin-bottom: 10px; }
 
+.panel-panel .pane-content p { padding: 0; }
+
+.panel-panel .pane-content .views-row { padding: 0; }
+
 /* Enable overflow on front panel panes
 /* of width 4 unless specifically disabled */
 .front .grid-4 .panel-pane:not(.panel-pane-fluidheight) .pane-content {
@@ -1221,9 +1225,6 @@ nav.navigation .secondary-menu>li a.active-trail {
 .region-sidebar-second .block .content .item-list li {
     margin-left: 0;
 }
-
-.panel-panel .pane-content .views-row,
-.panel-panel .pane-content .node { padding: 10px; }
 
 .panel-panel .pane-content .node {
     background: none;


### PR DESCRIPTION
There was padding on some internal elements that caused elements like the heading and news items to not be lined up on the left. I removed the offending padding.