### PR TITLE
LUGG-941 Added current year token to suitcase_interim block template

### DIFF
--- a/templates/default_region_content_blocks/footer_third.tpl.php
+++ b/templates/default_region_content_blocks/footer_third.tpl.php
@@ -1,4 +1,4 @@
-<p>Copyright &copy; <?php print date('Y'); ?>, Iowa State University of Science and Technology. All rights reserved.</p>
+<p>Copyright &copy; [current-date:custom:Y], Iowa State University of Science and Technology. All rights reserved.</p>
 <ul class="menu">
   <li class="first leaf">
     <a href="http://www.policy.iastate.edu/policy/discrimination">Non-discrimination Policy</a>

--- a/templates/default_region_content_blocks/footer_third.tpl.php
+++ b/templates/default_region_content_blocks/footer_third.tpl.php
@@ -1,4 +1,4 @@
-<p>Copyright &copy; [current-date:custom:Y], Iowa State University of Science and Technology. All rights reserved.</p>
+<p>Copyright &copy; <?php (module_exists('token_filter')) ? print('[current-date:custom:Y]') : print date('Y'); ?>, Iowa State University of Science and Technology. All rights reserved.</p>
 <ul class="menu">
   <li class="first leaf">
     <a href="http://www.policy.iastate.edu/policy/discrimination">Non-discrimination Policy</a>


### PR DESCRIPTION
This needs to go [with the changes I made in luggage_ckeditor](https://github.com/isubit/luggage_ckeditor/pull/23).
Basically, testing this just needs to find out whether the current year displays when you automagically create new footer blocks.