### PR TITLE
DIGITALAG-11 Modified width on content images.

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -321,7 +321,7 @@ figure .insert-default-image-styling + figcaption {
 
 .region-content img {
     height: auto !important;
-    max-width: 100%; 
+    max-width: calc(100% - 1rem); 
     margin: 0.5rem;
 }
 


### PR DESCRIPTION
The margin was pushing images outside of available space. Reducing the max-width to accommodate the margins keeps everything together.