### PR TITLE
INTERIM-39 Mobile fixes

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1768,6 +1768,10 @@ span.date-display-single {
     width: 100%;
 }
 
+.views-field-field-uri-1 {
+    margin-bottom: 1rem;
+}
+
 .views-field-field-uri-1 a {
     color: #616161;
     word-wrap: break-word;

--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1768,6 +1768,13 @@ span.date-display-single {
     width: 100%;
 }
 
+.views-field-field-uri-1 a {
+    color: #616161;
+    word-wrap: break-word;
+    -ms-word-break: break-all;
+    word-break: break-all;
+}
+
 /* -------------------- */
 /* ## VIEWS - PEOPLE 
 /* -------------------- */

--- a/css/suitcase_responsive.css
+++ b/css/suitcase_responsive.css
@@ -108,6 +108,25 @@
     }
 }
 
+@media all and (max-width: 550px) {
+
+    .node-people .field-label-inline .field-label,
+    .node-people .field-lable-inline .field-items,
+    .node-people .field-label-above .field-label,
+    .node-people .field-lable-above .field-items {
+        display: block;
+        width: auto;
+        margin-bottom: 0.5rem;
+        float: none;
+        text-align: left;
+    }
+
+    .node-people .field-label-inline,
+    .node-people .field-label-above {
+        padding: 1rem;
+    }
+}
+
 @media all and (max-width: 739px) {
 
     .region-isu-menu {

--- a/css/suitcase_responsive.css
+++ b/css/suitcase_responsive.css
@@ -163,6 +163,10 @@
     .panel-2col-bricks .panel-col-last .inside {
         margin: 0;
     }
+
+    .view-luggage-announcements .flexslider .flex-caption {
+          position: static;
+    }
 }
 
 @media all and (max-width: 979px) {
@@ -171,11 +175,6 @@
         word-wrap: break-word;
         -ms-word-break: break-all;
         word-break: break-all;
-    }
-
-    .view .field-content a {
-        display: block;
-        width: 100%;
     }
 
     .zone-content h2.block-title {


### PR DESCRIPTION
Contains pre-CSS refactor fixes for:

- Long URLs donking up resource view display
- URL padding in resource views
- People labels mush into their content on mobile
- The main menu gets covered up by flexslider slide labels