### PR TITLE
INTERIM-65 Change wordmark link default

### DIFF
--- a/templates/region--branding.tpl.php
+++ b/templates/region--branding.tpl.php
@@ -4,9 +4,9 @@
 
         <?php if ($show_isu_nameplate): ?>
             <?php if (theme_get_setting('default_logo', 'suitcase_interim')): ?>
-              <a id="isu_header_wordmark" href="<?php ($level_1_url) ? print $level_1_url : 'http://www.iastate.edu' ?>" title="Iowa State University Homepage"><img src="<?php print $wordmark_image; ?>" alt="Iowa State University"></a>
+              <a id="isu_header_wordmark" href="<?php print $level_1_url; ?>" title="Iowa State University Homepage"><img src="<?php print $wordmark_image; ?>" alt="Iowa State University"></a>
             <?php else: ?>
-              <a id="isu_header_wordmark" href="<?php ($level_1_url) ? print $level_1_url : 'http://www.iastate.edu' ?>" title="<?php print $site_name; ?>"><img src="<?php print $wordmark_image; ?>" alt="Iowa State University - <?php print $site_name; ?>"></a>
+              <a id="isu_header_wordmark" href="<?php print $level_1_url; ?>" title="<?php print $site_name; ?>"><img src="<?php print $wordmark_image; ?>" alt="Iowa State University - <?php print $site_name; ?>"></a>
             <?php endif; ?>
         <?php endif; ?>
 

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -81,7 +81,7 @@ function suitcase_interim_form_system_theme_settings_alter(&$form, &$form_state)
       '#type' => 'textfield',
       '#title' => t('Wordmark URL'),
       '#description' => t('Full URL the Iowa State University wordmark should link to. Defaults to site\'s homepage.'),
-      '#default_value' => variable_get('suitcase_interim_config_level_1_url', NULL),
+      '#default_value' => variable_get('suitcase_interim_config_level_1_url', $GLOBALS['base_url']),
       '#weight' => 2,
     );
 

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -80,8 +80,8 @@ function suitcase_interim_form_system_theme_settings_alter(&$form, &$form_state)
     $form['suitcase_interim_config']['suitcase_interim_config_logo']['suitcase_interim_config_level_1_url'] = array(
       '#type' => 'textfield',
       '#title' => t('Wordmark URL'),
-      '#description' => t('Full URL the Iowa State University wordmark should link to. Defaults to \'http://www.iastate.edu/\''),
-      '#default_value' => variable_get('suitcase_interim_config_level_1_url', 'http://www.iastate.edu/'),
+      '#description' => t('Full URL the Iowa State University wordmark should link to. Defaults to site\'s homepage.'),
+      '#default_value' => variable_get('suitcase_interim_config_level_1_url', NULL),
       '#weight' => 2,
     );
 


### PR DESCRIPTION
By default, the wordmark should link to the site's homepage instead of www.iastate.edu