### PR TITLE
HHPN-142 Padding and height were hiding input text

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -488,8 +488,9 @@ figure.image.floated-right img {
 /* Forms */
 
 input[type=text] {
+    height: auto;
     max-width: 100%;
-    padding: 1em;
+    padding: 0.5rem;
     border: 1px solid #ddd;
     border-radius: 2px;
 }


### PR DESCRIPTION
This rule catches text inputs not already styled more specifically,
like the content creation forms and search boxes.