### PR TITLE
INTERIM-99 Removed right padding from node add fields

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -2639,7 +2639,6 @@ td.views-field-field-resource-screenshot img {
     height: auto !important;
     margin-top: 0.5rem !important;
     padding: 0.5rem;
-    padding-right: 1.15rem;
     font-size: 1rem;
 }
 


### PR DESCRIPTION
The increased padding on node/add forms made luggage_people fields too big. This fixes that.

Review this by looking at each node/add form to make sure the form fields don't have unexpected wonkiness.