### PR TITLE
NREM-211 Override explicit heights set so images can be responsive

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -440,7 +440,7 @@ img {
 
 /* Target only images in content */
 .field-name-body img {
-    height: auto;
+    height: auto !important;
     max-width: calc(100% - 1rem);
     margin: 0.5rem;
 }


### PR DESCRIPTION
Right now explicit heights set in the WYSIWYG may force some images to
warp when the window narrows. This is the responsive images fix.