### PR TITLE
INTERIM-134 Made taxonomy styling selectors more general

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1909,19 +1909,16 @@ ul.menu li {
 /* Field Name: Field Tags */
 /* Field Name: Field Category */
 
-.field-name-field-tags .field-label,
-.field-name-field-category .field-label {
+.field-type-taxonomy-term-reference .field-label {
     margin-top: 2px;
     margin-bottom: 5px;
 }
 
-.field-name-field-tags .field-item,
-.field-name-field-category .field-item {
+.field-type-taxonomy-term-reference .field-item {
     display: inline-block;
 }
 
-.field-name-field-tags .field-item a,
-.field-name-field-category .field-item a {
+.field-type-taxonomy-term-reference .field-item a {
     display: inline-block;
     margin-right: 0.5em;
     margin-bottom: 0.5rem;
@@ -1933,8 +1930,7 @@ ul.menu li {
     border: 1px solid #e2e2e2;
     transition: background 0.25s ease;
 }
-    .field-name-field-tags .field-item a:hover,
-    .field-name-field-category .field-item a:hover {
+    .field-type-taxonomy-term-reference .field-item a:hover {
         text-decoration: none;
         background: #f5f5f5;
     }


### PR DESCRIPTION
Started trying to fix taxonomy term styling and realized I was playing whack-a-mole. This is a bigger hammer, but should stop any new taxonomy vocabularies from being unstyled in the future.

To test:
- Pull down these changes, make sure you have events and news items on your site.
- Clear cache a bunch
- Look at one of your news items. How do news types look?
- Go to the news and event lists. How do taxonomy terms look there? Are they nice and styled like the taxonomy terms on news items/event pages?
- Make a new taxonomy and give it some terms. Add it to a content type. Make sure you change the display settings so that it shows on full page content with the same viewing options as other taxonomies (like categories and tags). Is it styled?