### PR TITLE
Interim 137

### DIFF
--- a/preprocess/preprocess-region.inc
+++ b/preprocess/preprocess-region.inc
@@ -33,7 +33,7 @@ function suitcase_interim_alpha_preprocess_region(&$vars) {
     $vars['suitcase_interim_config_header_type'] = variable_get('suitcase_interim_config_header_type', 1);
 
     // Get the uploaded wordmark if is exists and the header type allows
-    $vars['wordmark_image'] = (theme_get_setting('default_logo', 'suitcase_interim')) ? file_create_url(drupal_get_path('theme', 'suitcase_interim') . '/images/isu.svg') : file_create_url(theme_get_setting('logo_path', 'suitcase_interim'));
+    $vars['wordmark_image'] = (theme_get_setting('default_logo')) ? file_create_url(drupal_get_path('theme', 'suitcase_interim') . '/images/isu.svg') : file_create_url(theme_get_setting('logo_path'));
 
   }
   elseif ($vars['region'] == 'menu') {

--- a/templates/form--system-theme-settings.tpl.php
+++ b/templates/form--system-theme-settings.tpl.php
@@ -5,7 +5,7 @@
  */
 ?>
 <div id="suitcase-interim-header-preview">
-  <?php $wordmark_path = (theme_get_setting('default_logo', 'suitcase_interim')) ? file_create_url(drupal_get_path('theme', 'suitcase_interim') . '/images/isu.svg') : file_create_url(theme_get_setting('logo_path', 'suitcase_interim')); ?>
+  <?php $wordmark_path = (theme_get_setting('default_logo', variable_get('theme_default'))) ? file_create_url(drupal_get_path('theme', 'suitcase_interim') . '/images/isu.svg') : file_create_url(theme_get_setting('logo_path', variable_get('theme_default'))); ?>
   <div class="container-12 clearfix">
     <div class="grid-6 suitcase-interim-vertical-tabs clearfix">
       <ul class="suitcase-interim-vertical-tabs-list">

--- a/templates/region--branding.tpl.php
+++ b/templates/region--branding.tpl.php
@@ -3,7 +3,7 @@
     <?php if ($site_name || $site_slogan): ?>
 
         <?php if ($show_isu_nameplate): ?>
-            <?php if (theme_get_setting('default_logo', 'suitcase_interim')): ?>
+            <?php if (theme_get_setting('default_logo')): ?>
               <a id="isu_header_wordmark" href="<?php print $level_1_url; ?>" title="Iowa State University Homepage"><img src="<?php print $wordmark_image; ?>" alt="Iowa State University"></a>
             <?php else: ?>
               <a id="isu_header_wordmark" href="<?php print $level_1_url; ?>" title="<?php print $site_name; ?>"><img src="<?php print $wordmark_image; ?>" alt="Iowa State University - <?php print $site_name; ?>"></a>

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -48,7 +48,7 @@ function suitcase_interim_form_system_theme_settings_alter(&$form, &$form_state)
     $form['suitcase_interim_config']['suitcase_interim_config_logo']['default_logo'] = array(
       '#type' => 'checkbox',
       '#title' => t('Use the default ISU wordmark'),
-      '#default_value' => theme_get_setting('default_logo', 'suitcase_interim'),
+      '#default_value' => theme_get_setting('default_logo'),
       '#tree' => FALSE,
       '#description' => t('Check here if you want to use the default ISU wordmark.')
     );
@@ -67,7 +67,7 @@ function suitcase_interim_form_system_theme_settings_alter(&$form, &$form_state)
       '#type' => 'textfield',
       '#title' => t('Path to custom wordmark'),
       '#description' => t('The path to the file you would like to use as your logo file instead of the ISU wordmark.'),
-      '#default_value' => theme_get_setting('logo_path', 'suitcase_interim'),
+      '#default_value' => theme_get_setting('logo_path'),
     );
 
     $form['suitcase_interim_config']['suitcase_interim_config_logo']['settings']['logo_upload'] = array(


### PR DESCRIPTION
Whilst subtheming Suitcase Interim, I found that that I could not change the logo, in any way, in my subtheme.  This is a result of Suitcase Interim's logo settings and displays being hardcoded to check against Suitcase Interim theme values explicitly.  This PR should fix that.