### PR TITLE
Removed Iowa State University from alt-text

### DIFF
--- a/templates/region--branding.tpl.php
+++ b/templates/region--branding.tpl.php
@@ -6,7 +6,7 @@
             <?php if (theme_get_setting('default_logo', 'suitcase_interim')): ?>
               <a id="isu_header_wordmark" href="<?php print $level_1_url; ?>" title="Iowa State University Homepage"><img src="<?php print $wordmark_image; ?>" alt="Iowa State University"></a>
             <?php else: ?>
-              <a id="isu_header_wordmark" href="<?php print $level_1_url; ?>" title="<?php print $site_name; ?>"><img src="<?php print $wordmark_image; ?>" alt="Iowa State University - <?php print $site_name; ?>"></a>
+              <a id="isu_header_wordmark" href="<?php print $level_1_url; ?>" title="<?php print $site_name; ?>"><img src="<?php print $wordmark_image; ?>" alt="<?php print $site_name; ?>"></a>
             <?php endif; ?>
         <?php endif; ?>
 


### PR DESCRIPTION
Suitcase Interim currently has 'Iowa State University' in the alt-text.  On a Suitcase Interim subtheme this may be undesireable (e.g. grant site with multiple institutions involved).  Removing 'Iowa State University' and leaving $site_name should produce suitable alt-text without running afoul of branding. 