### PR TITLE
INTERIM-140 Added token replacement capability to suitcase_interim_block text format

### DIFF
--- a/theme-settings.php
+++ b/theme-settings.php
@@ -209,6 +209,12 @@ function suitcase_interim_config_form_submit($form, &$form_state) {
       $suitcase_interim_block_format = array(
         'format' => 'suitcase_interim_block',
         'name' => 'Suitcase Interim Block',
+        'filters' => array(
+          'filter_tokens' => array(
+            'weight' => 0,
+            'status' => 1,
+          ),
+        ),
       );
       $suitcase_interim_block_format = (object) $suitcase_interim_block_format;
       filter_format_save($suitcase_interim_block_format);


### PR DESCRIPTION
To test:
- Pull down a brand new luggage site with suitcase_interim and no content
- Grab and use this branch
- Add a site name in the suitcase_interim settings form (admin/appearance/settings/suitcase_interim)
- Check that the "Replace tokens" setting is enabled at admin/config/content/formats/suitcase_interim_block
- Make sure that the copyright date in the footer block displays as 2017 and not an ugly token