### PR TITLE
INTERIM-146 Improve layout of panels with 3 or 4 items in a row as th…

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1431,7 +1431,7 @@ ul.tabs.secondary img {
     color: #676767;
 }
 
-.panel-panel iframe {
+.panel-pane iframe {
     max-width: 100%;
 }
 
@@ -1493,6 +1493,24 @@ in the panel settings */
 
 .megapanels-wrapper_full_top {
     margin-bottom: 1rem;
+}
+
+@media (max-width: 1139px) and (min-width: 600px) {
+
+    .megapanels-pane:first-child:nth-last-child(4),
+    .megapanels-pane:first-child:nth-last-child(4) ~ .megapanels-pane {
+      width: calc(50% - 1rem);
+      flex: 0 1 auto;
+    } 
+}
+
+@media (max-width: 829px) {
+
+    .megapanels-pane:first-child:nth-last-child(3),
+    .megapanels-pane:first-child:nth-last-child(3) ~ .megapanels-pane {
+      width: calc(50% - 1rem);
+      flex: 0 1 auto;
+    }
 }
 
 /* ---------------------------------------- */

--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1504,7 +1504,7 @@ in the panel settings */
     } 
 }
 
-@media (max-width: 829px) {
+@media (max-width: 829px) and (min-width: 548px) {
 
     .megapanels-pane:first-child:nth-last-child(3),
     .megapanels-pane:first-child:nth-last-child(3) ~ .megapanels-pane {


### PR DESCRIPTION
Improve layout of panels with 3 or 4 items in a row as they transition to narrow breakpoints.

To Test:
- Create a panel page, and fill in 3 and 4 panes in rows.
- Narrow the browser. The layouts should look like this:

![screen shot 2017-12-21 at 10 03 57 am](https://user-images.githubusercontent.com/24654361/34784317-8af8cd04-f5f3-11e7-9765-999aba4d6180.png)
