### PR TITLE
LDOC-69 Adjusted the margin/padding strategy for images in gridrows, …

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -813,7 +813,13 @@ input[type=submit].form-submit {
 .luggage-gridrow3 img,
 .luggage-gridrow4 img {
     float: left;
-    padding: 0 1rem 1rem 0;
+    margin: 0 1rem 1rem 0;
+}
+
+.luggage-grid.luggage-grid_no-float .luggage-gridrow img,
+.luggage-grid.luggage-grid_no-float .luggage-gridrow3 img,
+.luggage-grid.luggage-grid_no-float .luggage-gridrow4 img {
+    float: none;
 }
 
 .luggage-gridrow,
@@ -2429,10 +2435,7 @@ td.multi-day .calendar.dayview a {
 
 /* --- Screenshot Preview --- */
 
-.views-field-field-resource-screenshot {
-    margin-right: 1rem;
-    margin-bottom: 0.25rem;
-    float: left;
+.views-field-field-resource-screenshot img {
     border: 1px solid #ddd;
 }
 


### PR DESCRIPTION
…as seen in Resources and People (and used manually in other Views)

We can test this by looking at the changes on People or Resources features, or looking at Views created manually using the luggage-grid strategy. (https://github.com/isubit/suitcase_interim/wiki/Responsive-Grid-for-Views)

Also created a luggage-grid_no-float class that can be added to the view to stop the image from floating.