### PR TITLE
INTERIM-148 Updated template file to include the missing div

### DIFF
--- a/templates/section.tpl.php
+++ b/templates/section.tpl.php
@@ -1,3 +1,5 @@
 <div<?php print $attributes; ?>
-  <?php print $content; ?>
+  <div id="zone-content-wrapper" class="zone-wrapper zone-content-wrapper clearfix">
+    <?php print $content; ?>
+  </div
 </div>


### PR DESCRIPTION
This fixes our template issue by manually adding the missing div in. It should be tested on pages with blocks in the sidebar.