### PR TITLE
INTERIM-149 Change i elements to span

### DIFF
--- a/template.php
+++ b/template.php
@@ -363,7 +363,7 @@ function suitcase_interim_menu_link__menu_social($variables) {
   }
 
   if (!empty($font_awesome_icon)) {
-    $element['#title'] = '<i class="fa ' . $font_awesome_icon . '" aria-hidden="true"></i><span class="social-title"> ' . $element['#title'] . '</span>';
+    $element['#title'] = '<span class="fa ' . $font_awesome_icon . '" aria-hidden="true"></span><span class="social-title"> ' . $element['#title'] . '</span>';
     $element['#localized_options']['html'] = TRUE;
   }
 

--- a/templates/default_region_content_blocks/footer_third.tpl.php
+++ b/templates/default_region_content_blocks/footer_third.tpl.php
@@ -1,8 +1,8 @@
 <ul class="menu">
   <li class="first leaf">
-    <a href="<?php print (module_exists('token_filter') ? '[site:url]' : $GLOBALS['base_path']); ?>site-index"><i class="fa fa-list-ul" aria-hidden="true"></i>Site Index</a>
+    <a href="<?php print (module_exists('token_filter') ? '[site:url]' : $GLOBALS['base_path']); ?>site-index"><span class="fa fa-list-ul" aria-hidden="true"></span>Site Index</a>
   </li>
   <li class="last leaf">
-    <a href="<?php print (module_exists('token_filter') ? '[site:url]' : $GLOBALS['base_path']); ?>sitemap" title="Display a site map with RSS feeds."><i class="fa fa-sitemap" aria-hidden="true"></i>Site map</a>
+    <a href="<?php print (module_exists('token_filter') ? '[site:url]' : $GLOBALS['base_path']); ?>sitemap" title="Display a site map with RSS feeds."><span class="fa fa-sitemap" aria-hidden="true"></span>Site map</a>
   </li>
 </ul>


### PR DESCRIPTION
This pull request changes i elements to span in generated blocks with fontawesome icons.

To test:
- pull down this pr on a local copy of a site
- if you're on an existing site, delete the footer blocks with fontawesome icons
- (re)save your theme settings to make new blocks
- check to make sure that the fontawesome icons show up properly, aren't missing closing tags, etc.