### PR TITLE
Interim 146 - IE fix for megapanels

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1477,7 +1477,7 @@ in the panel settings */
     }
 
 .megapanels-pane {
-    flex: 1 1 250px;
+    flex: 1 1 0px;
     min-width: 250px;
     margin: 0 0.5rem;
     margin-bottom: 1rem;

--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1510,7 +1510,7 @@ in the panel settings */
     } 
 }
 
-@media (max-width: 829px) and (min-width: 548px) {
+@media (max-width: 850px) and (min-width: 548px) {
 
     .megapanels-pane:first-child:nth-last-child(3),
     .megapanels-pane:first-child:nth-last-child(3) ~ .megapanels-pane {


### PR DESCRIPTION
To test: 
1. Create a Panels page using the Megapanels layout and make a rows of 2 items, 3 items, and 4 items.
2. In IE11, Safari, Chrome, and Firefox, do they behave like this?:
![screen shot 2017-12-21 at 10 03 57 am](https://user-images.githubusercontent.com/24654361/35344822-a44db340-00f3-11e8-848c-d826b6c822cc.png)

This had previously worked well in other browsers, so we want to make sure this fixes it in IE, and doesn't break it on the other browsers.