### PR TITLE
INTERIM-151 Remove redundant WAI-ARIA attribute

### DIFF
--- a/preprocess/preprocess-region.inc
+++ b/preprocess/preprocess-region.inc
@@ -58,7 +58,4 @@ function suitcase_interim_alpha_preprocess_region(&$vars) {
     unset($vars['elements']['#grid']);
     unset($vars['elements']['#grid_container']);
   }
-  elseif (strpos($vars['region'], 'sidebar') === 0) {
-    $vars['attributes_array']['role'] = 'complementary';
-  }
 }

--- a/templates/region--content.tpl.php
+++ b/templates/region--content.tpl.php
@@ -1,4 +1,4 @@
-<main role="main"<?php print $attributes; ?>>
+<main <?php print $attributes; ?>>
   <div<?php print $content_attributes; ?>>
     <a id="main-content"></a>
     <?php print render($title_prefix); ?>

--- a/templates/region--isu_menu.tpl.php
+++ b/templates/region--isu_menu.tpl.php
@@ -1,7 +1,7 @@
 <div<?php print $attributes; ?>>
     <div<?php print $content_attributes; ?>>
       <?php print $content; ?>
-        <nav id="isu-menu-nav" class="navigation" role="navigation">
+        <nav id="isu-menu-nav" class="navigation">
 
             <h2 class="element-invisible">ISU Index Menu</h2>
 

--- a/templates/region--isu_menu.tpl.php
+++ b/templates/region--isu_menu.tpl.php
@@ -1,9 +1,9 @@
 <div<?php print $attributes; ?>>
     <div<?php print $content_attributes; ?>>
       <?php print $content; ?>
-        <nav id="isu-menu-nav" class="navigation">
+        <nav id="isu-menu-nav" class="navigation" aria-labelledby="isu-index isu-quick-links">
 
-            <h2 class="element-invisible">ISU Index Menu</h2>
+            <h2 id="isu-index" class="element-invisible">ISU Index Menu</h2>
 
             <ul id="isu-index-menu" class="sm" data-sm-options="{ subIndicatorsText: '', subMenusMinWidth: '', subMenusMaxWidth: '', subIndicatorsPos: 'append' }">
                 <li><a href="https://www.iastate.edu" title="Iowa State University Home Page">iastate.edu</a></li>
@@ -40,7 +40,7 @@
                 </li>
             </ul>
 
-            <h2 class="element-invisible">ISU Quick Links Menu</h2>
+            <h2 id="isu-quick-links" class="element-invisible">ISU Quick Links Menu</h2>
 
             <ul id="isu-quick-links-menu" class="sm" data-sm-options="{ subIndicatorsText: '', subMenusMinWidth: '', subMenusMaxWidth: '', subIndicatorsPos: 'append' }">
                 <li><a href="https://info.iastate.edu/">Directory</a></li>

--- a/templates/region--menu.tpl.php
+++ b/templates/region--menu.tpl.php
@@ -3,7 +3,7 @@
     <?php print $content; ?>
 
     <?php if ($main_menu_smartmenu): ?>
-    <nav id="main-menu-nav" class="navigation" role="navigation">
+    <nav id="main-menu-nav" class="navigation" >
 
       <h2 class="element-invisible">Main menu</h2>
 

--- a/templates/region--menu.tpl.php
+++ b/templates/region--menu.tpl.php
@@ -3,9 +3,9 @@
     <?php print $content; ?>
 
     <?php if ($main_menu_smartmenu): ?>
-    <nav id="main-menu-nav" class="navigation" >
+    <nav id="main-menu-nav" class="navigation" aria-labelledby="main-menu-label">
 
-      <h2 class="element-invisible">Main menu</h2>
+      <h2 id="main-menu-label" class="element-invisible">Main menu</h2>
 
       <!-- Mobile menu toggle button (hamburger/x icon) -->
       <input id="main-menu-state" class="sm-menu-state" type="checkbox" />


### PR DESCRIPTION
This pull request should remove aria roles where they're not needed.

To test:
- pull down this branch
- run `drush registry-rebuild` and clear caches
- look over site pages with the siteimprove extension. do you still see the `Name, Role, Value 4.1.2` warnings?
- do you notice any new errors about missing roles or no-distinguishable landmarks??