### PR TITLE
LUGG-1070 Fix flexslider link styling, and remove external indicator.

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -273,8 +273,10 @@ a:hover {
 #section-content .pane-menu-menu-social a.external:after,
 #section-content .block-menu-social a:after,
 #section-content .view-resources a.external:after,
-#section-content .bibio-entry a.external:after {
+#section-content .bibio-entry a.external:after,
+#section-content .flex-caption a.external:after {
     content: '';
+    display: none;
 }
 
 /* -------------------- */
@@ -1373,8 +1375,16 @@ ul.tabs.secondary img {
     border: 1px solid #bbb;
 }
 
-.flex-caption a {
+.flex-caption a,
+.flex-caption a > p {
+    color: #cc0000;
     text-decoration: none;
+}
+
+.flex-caption a:hover,
+.flex-caption a:hover > p {
+    color: #0062a0;
+    text-decoration: underline;
 }
 
 .flex-caption p {


### PR DESCRIPTION
This adjusts the link styling on the Announcement flexslider. 

Before: 
![screen shot 2018-02-20 at 9 07 41 am](https://user-images.githubusercontent.com/24654361/36431561-8e2898c0-161d-11e8-85ad-159445129c4d.png)

Desired After: 
![screen shot 2018-02-20 at 9 07 19 am](https://user-images.githubusercontent.com/24654361/36431568-931c8a26-161d-11e8-9a24-e43e5c94eb58.png)

To test: 
* Pull down this branch of Interim and make an Announcement flexslider with an *external* alternate url, and Caption.

I'm hoping the external link icon is gone, the link text is red, and is blue on hover.