### PR TITLE
DIGITALAG-46 Leaky selector for item-list

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1788,7 +1788,7 @@ aside.region {
     margin: 0 0 1rem 0;
 }
 
-.item-list ul li a {
+.item-list ul > li > a {
     display: block;
 }
 


### PR DESCRIPTION
.item-list is used in many views to unstyle an unordered list, which is helpful. This selector was being too powerful and catching a elements that didn't need to be display block. This change *should* catch only the sort of "list of links" that it was intended for.

To test it, I must hunt around in different Views that are known to have links in unordered lists.