### PR TITLE
WILE-48 Fix Grow Panel resize bug

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1475,7 +1475,7 @@ in the panel settings */
     }
 
 .megapanels-pane {
-    flex: 1 1 0px;
+    flex: 1 1 250px;
     min-width: 250px;
     margin: 0 0.5rem;
     margin-bottom: 1rem;
@@ -1499,7 +1499,17 @@ in the panel settings */
     margin-bottom: 1rem;
 }
 
-@media (max-width: 1139px) and (min-width: 600px) {
+@media (min-width: 1141px) {
+
+    .megapanels-pane:first-child:nth-last-child(4),
+    .megapanels-pane:first-child:nth-last-child(4) ~ .megapanels-pane {
+      width: calc(25% - 1rem);
+      flex: 0 1 auto;
+      min-width: 0;
+    } 
+}
+
+@media (max-width: 1140px) and (min-width: 600px) {
 
     .megapanels-pane:first-child:nth-last-child(4),
     .megapanels-pane:first-child:nth-last-child(4) ~ .megapanels-pane {
@@ -1508,7 +1518,7 @@ in the panel settings */
     } 
 }
 
-@media (max-width: 850px) and (min-width: 548px) {
+@media (max-width: 1000px) and (min-width: 548px) {
 
     .megapanels-pane:first-child:nth-last-child(3),
     .megapanels-pane:first-child:nth-last-child(3) ~ .megapanels-pane {


### PR DESCRIPTION
A previous fix for panel wrapping was not compatible with Grow Panels. This fix should:

1. Allow rows of 3 and 4 panels to wrap properly, with any orphans not slamming out to full width.
2. Not allow Grow Panels to smush their sibling panels too small. They should look about 1/3 but they were being mushed to something more like 1/4.