### PR TITLE
INTERIM-148 Add aria-label to content section

### DIFF
--- a/preprocess/preprocess-section.inc
+++ b/preprocess/preprocess-section.inc
@@ -10,4 +10,7 @@ function suitcase_interim_alpha_preprocess_section(&$vars) {
   if ($vars['elements']['#section'] == 'footer') {
     $vars['attributes_array']['role'] = 'contentinfo';
   }
+  if ($vars['elements']['#section'] == 'content') {
+    $vars['attributes_array']['aria-label'] = 'main content';
+  }
 }

--- a/templates/section.tpl.php
+++ b/templates/section.tpl.php
@@ -1,5 +1,0 @@
-<div<?php print $attributes; ?>
-  <div id="zone-content-wrapper" class="zone-wrapper zone-content-wrapper clearfix">
-    <?php print $content; ?>
-  </div>
-</div>


### PR DESCRIPTION
We want to preserve the section element so that our pages make sense semantically. However, our section element needs an aria-label so screenreaders can tell why it's there. This pull request adds an aria-label to the main content section.