### PR TITLE
LUGG-1063 Check if content links are renderable

### DIFF
--- a/templates/node.tpl.php
+++ b/templates/node.tpl.php
@@ -21,7 +21,7 @@
   </div>
   
   <div class="clearfix">
-    <?php if (!empty($content['links'])): ?>
+    <?php if (render($content['links'])): ?>
       <nav class="links node-links clearfix"><?php print render($content['links']); ?></nav>
     <?php endif; ?>
 

--- a/templates/node.tpl.php
+++ b/templates/node.tpl.php
@@ -22,7 +22,9 @@
   
   <div class="clearfix">
     <?php if (render($content['links'])): ?>
-      <nav class="links node-links clearfix"><?php print render($content['links']); ?></nav>
+      <div role="toolbar" class="links node-links clearfix">
+        <?php print render($content['links']); ?>
+      </div>
     <?php endif; ?>
 
     <?php print render($content['comments']); ?>


### PR DESCRIPTION
Right now, this conditional will always resolve to true even if there isn't content to render because the content links array isn't ever empty even when it isn't renderable. This means that we have an empty nav hanging out on all of our nodes, which is an accessibility issue. This pr changes the conditional to check whether or not the content links are renderable before attempting to put them on the page.