### PR TITLE
INTERIM-161 Removed a rule that was hiding a border on the first row …

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -2114,8 +2114,6 @@ table.responsive-table,
         border-bottom: 3px solid #bbb;
     }
     
-    .responsive-table.table-row tr:first-of-type { border-bottom: 0; }
-    
     .responsive-table.table-row td { 
         display: flex; 
         padding: 0;


### PR DESCRIPTION
Removed a rule that was hiding a border on the first row of data when a table used <thead>

Luggage does not use `<thead>` in tables so the effect for that platform will be a thicker border at the top of tables on mobile, which looks fine.

The effect when a table has a `<thead>` is that the first row of data will get it's border-bottom back on mobile.