### PR TITLE
INTERIM-170 Add support for Display Suite custom wrappers in the Medi…

### DIFF
--- a/panels/layouts/media_card/media-card.tpl.php
+++ b/panels/layouts/media_card/media-card.tpl.php
@@ -1,22 +1,27 @@
-<div class="media media_card" <?php if (!empty($css_id)) { print "id=\"$css_id\""; } ?>>
+<<?php print $layout_wrapper; print $layout_attributes; ?> class="media media_card <?php print $classes;?>">
+
+  <?php if (isset($title_suffix['contextual_links'])): ?>
+  <?php print render($title_suffix['contextual_links']); ?>
+  <?php endif; ?>
 
   <?php if (!empty($content['media_left'])): ?>
-    <div class="media-left">
+    <<?php print $media_left_wrapper ?> class="media-left <?php print $media_left_classes; ?>">
       <?php print $content['media_left']; ?>
-    </div>
+    </<?php print $media_left_wrapper ?>>
   <?php endif; ?>
 
   <div class="media-body">
     <?php if (!empty($content['media_heading'])): ?>
-      <div class="media-heading">
+      <<?php print $media_heading_wrapper ?> class="media-heading <?php print $media_heading_classes; ?>">
         <?php print $content['media_heading']; ?>
-      </div>
+      </<?php print $media_heading_wrapper ?>>
     <?php endif; ?>
 
     <?php if (!empty($content['media_body'])): ?>
-      <div class="media-content">
+      <<?php print $media_body_wrapper ?> class="media-content <?php print $media_body_classes; ?>">
         <?php print $content['media_body']; ?>
-      </div>
+      </<?php print $media_body_wrapper ?>>
     <?php endif; ?>
   </div>
-</div>
+
+</<?php print $layout_wrapper ?>>


### PR DESCRIPTION
The Display Suite UI allows us to change the wrappers for layout regions. Currently, Media Card isn't templated to apply those settings. 

To test:
1. Content Type > Manage Display > choose a View Mode (like Teaser)
2. Change the layout to Media Card and move some fields into the regions.
3. Go down to 'Custom Wrappers' and change the wrappers for each Region and Layout to something else.
4. Do you see the changes reflected in the DOM? 
5. Does the layout still work as expected?