### PR TITLE
INTERIM-171 Make overflow pane taller

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1475,7 +1475,7 @@ in the panel settings */
 .panel-pane-overflow .pane-content, 
 .pane-twitter-block-1 .pane-content,
 .pane-views-instagrams-block .pane-content {
-    height: 350px;
+    height: 500px;
     overflow-y: scroll;
 }
 


### PR DESCRIPTION
To test:
- pull down branch
- add the `.panel-pane-overflow ` class to a panel block
- make some tall block content
- add some other blocks into the same row
- does the overflow content height match the other blocks' heights?