### PR TITLE
INTERIM-175 Just in case Suitcase Interim is being used on admin pages.

### DIFF
--- a/panels/layouts/suitcase_megapanels/suitcase_megapanels_admin.css
+++ b/panels/layouts/suitcase_megapanels/suitcase_megapanels_admin.css
@@ -1,7 +1,12 @@
 .megapanels-row {
   display: flex;
+  flex-wrap: nowrap !important;
+  margin: 0 !important;
 }
 
 .megapanels-pane {
-  flex: 1 1 100%;
+  flex: 1 1 100% !important;
+  min-width: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
 }


### PR DESCRIPTION
If Suitcase Interim was being used for admin pages, the layout of the Panes on the Layout screen of a Panel page was jumbled. This was because Suitcase Interim has extra CSS to actually style panels that don't work for the admin page. This change overrides those styles to make a simple grid.