### PR TITLE
INTERIM-178 Adjust padding on the top and bottom full Mega Panels panes

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1701,6 +1701,20 @@ ul.tabs.secondary img {
     margin-bottom: 1rem;
 }
 
+.megapanels-wrapper_full_top,
+.megapanels-wrapper_full_bottom {
+    margin-right: 0.5rem;
+    margin-left: 0.5rem;
+}
+
+@media (max-width: 740px) {
+    .megapanels-wrapper_full_top,
+    .megapanels-wrapper_full_bottom {
+        margin-right: 2rem;
+        margin-left: 2rem;
+    }
+}
+
 @media (min-width: 1141px) {
 
     .megapanels-pane:first-child:nth-last-child(4),

--- a/panels/layouts/suitcase_megapanels/suitcase-megapanels.tpl.php
+++ b/panels/layouts/suitcase_megapanels/suitcase-megapanels.tpl.php
@@ -131,7 +131,7 @@
 	</div>
 
 	<?php if (!empty($content['bottom_full'])): ?>
-		<div class="megapanels_wrapper">
+		<div class="megapanels_wrapper megapanels-wrapper_full_top">
 			<div class="megapanels-full megapanels-full_bottom">
 				<div class="megapanels-pane_full">
 					<?php print $content['bottom_full']; ?>


### PR DESCRIPTION
See INTERIM-178 in Jira. Right now, blocks placed in the Top Full or Bottom Full panes in MegaPanels expand to touch the edge of the browser on narrow screens. That's not working out. 

This PR makes the padding the same as the other rows.