### PR TITLE
Interim 180

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1759,8 +1759,14 @@ ul.tabs.secondary img {
     margin: 0;
 }
 
+.megapanels_full-width .megapanels-wrapper_full_top,
+.megapanels_full-width .megapanels-wrapper_full_bottom {
+  margin-right: 0;
+  margin-left: 0;
+}
+
 .megapanels_full-width.megapanels_content-contained .megapanels-row {
-    border: 5px solid black;
+    
 }
 
 /* Mimic container-12 */
@@ -1781,7 +1787,8 @@ ul.tabs.secondary img {
 
 @media (min-width: 1200px) {
     .megapanels_full-width.megapanels_content-contained .megapanels-row {
-        max-width: 1200px;
+        width: 92%;
+        max-width: calc(1200px + 2rem);
         margin-left: auto !important;
         margin-right: auto !important;
     }
@@ -1789,6 +1796,10 @@ ul.tabs.secondary img {
 
 .megapanels_full-width.megapanels_content-contained .suitcase_megapanels {
     margin: 0;
+}
+
+.megapanels_full-width.megapanels_content-contained .megapanels-pane {
+  margin: 0;
 }
 
 /* ---------------------------------------- */


### PR DESCRIPTION
To Test:

1. Get a site down that is using a Panel page
2. Edit the panel and go to the General tab
3. Add both `megapanels_full-width megapanels_content-contained` classes to the Add body CSS classes field and Save.
4. Does it work the same as megapanels did before?
5. The power of this is adding a background color to `megapanels-wrapper_top` or `_middle` or `bottom`. I think you could add that code in the general tab under CSS code (but that's been a little buggy?) The css to add would be:

```.megapanels-wrapper_top { background: #ddd; }```

6. The background should stretch edge-to-edge but the content should stay in the middle as usual.
