### PR TITLE
LUGG-1160 Override luggage_video CSS for sizing videos

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -2950,6 +2950,16 @@ td.views-field-field-resource-screenshot img {
     height: 100%;
 }
 
+/* Strong override for luggage_video.css */
+
+.field-item .embedded-video {
+    position: static !important;
+    padding-bottom: 0;
+    padding-top: 0;
+    height: auto;
+    overflow: visible;
+}
+
 /* ---------------------------------------- */
 /* ## CONTENT EDITING
 /* ---------------------------------------- */


### PR DESCRIPTION
To Test:
1. Set up a luggage_bean_video
2. Choose a site that already has luggage_video modules in use
3. Switch Suitcase_Interim to   LUGG-1160 IN PROGRESS  
4. Are the luggage_video's working correctly? Are the black bars gone? Are they responsive?
5. Add a luggage_bean_video to a Panel page. Also working correctly still?
6. Try putting a luggage_bean_video in a mini-panel and put it in the content region of any node. This was where the bug appeared. Working?

