### PR TITLE
LUGG-1165 Duplicate content template to add ARIA role to alerts.

### DIFF
--- a/templates/zone--content.tpl.php
+++ b/templates/zone--content.tpl.php
@@ -1,0 +1,11 @@
+<?php if ($wrapper): ?><div<?php print $attributes; ?>><?php endif; ?>
+  <div<?php print $content_attributes; ?>>
+    <?php if ($breadcrumb): ?>
+      <div id="breadcrumb" class="grid-<?php print $columns; ?>"><?php print $breadcrumb; ?></div>
+    <?php endif; ?>
+    <?php if ($messages): ?>
+      <div id="messages" role="status" class="grid-<?php print $columns; ?>"><?php print $messages; ?></div>
+    <?php endif; ?>
+    <?php print $content; ?>
+  </div>
+<?php if ($wrapper): ?></div><?php endif; ?>


### PR DESCRIPTION
This affects the colored messages that show up at the top of the page when there's a warning, or to say you've successfully edited a page. They should now have ARIA role="status" which assistive technology can use.