### PR TITLE
INTERIM-29 Add a class to make a content link look like a button.

### DIFF
--- a/ckeditor.css
+++ b/ckeditor.css
@@ -25,6 +25,21 @@ blockquote {
 
 blockquote p { margin-top: 0; }
 
+a.link-button {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  color: #ffffff;
+  font-weight: 700;
+  text-decoration: none;
+  background: #cc0000;
+  border-radius: 3px;
+  transition: background 0.2s ease;
+}
+
+a.link-button:hover {
+  background: #333333;
+}
+
 /* -------------------- */
 /* ## General indentation & positioning classes */
 /* -------------------- */

--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -209,6 +209,28 @@ a:hover {
     margin-bottom: 1rem;
 }
 
+/* --- Content Buttons --- */
+/* Add the link-button class to a link in CKEditor to style it like
+ * a button. Remember, the link-button needs to be added to the list of 
+ * allowed classes in the Text Formatter.
+ */
+ 
+a.link-button {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  color: #ffffff;
+  font-weight: 700;
+  text-decoration: none;
+  background: #cc0000;
+  border-radius: 3px;
+  transition: background 0.2s ease;
+}
+
+a.link-button:hover {
+  background: #333333;
+}
+
+
 /* --- Read More --- */
 
 .read-more {


### PR DESCRIPTION
**To test:**

* Add `link-button` to the list of allowed classes in the WYSIWYG text formatter.
* Make a link in a page or something and add `link-button` to the Stylesheet Classes in the Advanced tab.
* Does the link look like a button in the CKEditor?
* Does the link look like a button in the published page?