### PR TITLE
INTERIM-184 Remove the responsive-table class from colspan/rowspan tables

### DIFF
--- a/js/suitcase_responsive_tables.js
+++ b/js/suitcase_responsive_tables.js
@@ -25,18 +25,21 @@ structure and assign classes.
 	var bothHeader = $(table.has('tr:nth-of-type(1) th:nth-of-type(2)').has('tr:nth-of-type(2) th:nth-of-type(1)'));
 	bothHeader.attr('class', 'table-both');
 	
+	/* --- All Responsive Tables --- */
+	table.addClass('responsive-table');
+
 	/* --- Colspan or Rowspan --- */
 	var tdColFreeze = $(table.has('td[colspan]'));
 	var thColFreeze = $(table.has('th[colspan]'));
 	var tdRowFreeze = $(table.has('td[rowspan]'));
 	var thRowFreeze = $(table.has('th[rowspan]'));
-	tdColFreeze.attr('class', 'table-freeze');
-	thColFreeze.attr('class', 'table-freeze');
-	tdRowFreeze.attr('class', 'table-freeze');
-	thRowFreeze.attr('class', 'table-freeze');
+	tdColFreeze.attr('class', 'table-freeze').removeClass('responsive-table');
+	thColFreeze.attr('class', 'table-freeze').removeClass('responsive-table');
+	tdRowFreeze.attr('class', 'table-freeze').removeClass('responsive-table');
+	thRowFreeze.attr('class', 'table-freeze').removeClass('responsive-table');
 
-	/* --- All Responsive Tables --- */
-	table.addClass('responsive-table');
+	
+
 
 /* --------------------- 
 Now apply any jQuery needed


### PR DESCRIPTION
Right now, wide tables with colspan and rowspan are getting squished on mobile. We need them to just be themselves and horizontally scroll. This branch makes sure to strip out the responsive-table class which wasn't allowing them to do that. 

To test: 
1. Make a table with many columns and use rowspan or colspan (or both) in the table.
2. Narrow the window.
3. Can you view the whole table by scrolling it left/right?
4. Is the table scrunched up at all?
5. Test some regular tables. Do they get the nice responsive table treatment, still?