### PR TITLE
INTERIM-185 Restyle figcaptions and stop them leaking out

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -451,7 +451,37 @@ sup { vertical-align: super; }
 /* -------------------- */
 /* Figures & Images */
 
-figure figcaption { color: #333333; }
+figure {
+  display: table;
+}
+
+figure > br {
+  display: none;
+}
+
+figure img {
+  display: block;
+  max-width: 100% !important;
+  margin: 0 !important;
+}
+
+figcaption {
+  display: table-caption;
+  max-width: none;
+  caption-side: bottom;
+  padding: 0.5rem;
+  color: #333333;
+  font-size: 0.9rem;
+  background: #eeeeee;
+}
+
+figure[style*="float:left"] {
+  margin: 0 1rem 0 0;
+}
+
+figure[style*="float:right"] {
+  margin: 0 0 0 1rem;
+}
 
 img {
     height: auto !important;


### PR DESCRIPTION
Right now if you have luggage_image2 enabled image captions are unstyled so hard to distinguish from the content. Also, if the caption is wider than the image, the caption extends past the image.

This PR wraps the caption in a grey box, and contains the caption. 

To test: 
Enable luggage_image2 and add some images with captions. Try big images, small images, short captions, and long captions. 

KNOWN ISSUES: It is difficult to get a captioned images to float. If you can get it to float, you'll see that the margins are dynamic to match where the space if depending if its floated left or right. 

You can do it like this ...
1. Insert an image.
2. Click align left or align right and at the same time, check the box for caption.
3. It should work.
It won't work if you go back and edit the page, or if you float an already captioned image. 
This problem is beyond the scope of this PR and has to do with how CKEditor modifies the HTML. 