### PR TITLE
INTERIM-186 Improve external link wrapping

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -287,8 +287,14 @@ a.link-button:hover {
     font-family: 'FontAwesome';
     font-size: 0.75em;
     display: inline-block;
+    width: 2rem;
+    margin-right: -2rem; /* Same as width. Helps prevent wrapping */
     margin-left: 4px;
     vertical-align: text-top;
+}
+
+#section-content a.external p {
+    display: inherit;
 }
 
 /* Exceptions */


### PR DESCRIPTION
There are a few rare cases when the external link indicator can wrap without its final word. 

1. If the link is in a table, the table cell doesn't account for the width of the external link indicator, so it will wrap without it. 
2. If the link contains a `p` element, such as in a luggage announcement caption. 

NOTE: Currently suitcase_interim excludes announcement links from the rule. But I fixed it anyway. 

To test: 
1. Pull down a suitcase_interim site
2. Make sure the external links javascript library is turned on under Appearance > Suitcase Interim > Settings > Advanced options > libraries tab
3. External link icons should wrap with the final word in the link.