### PR TITLE
INTERIM-179 Fix numbered flexslider button alignment on safari

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1562,6 +1562,7 @@ ul.tabs.secondary img {
 }
 
 .flexslider-numbered .flex-pauseplay {
+  display: inline-flex;
   height: 2.5rem;
   margin-top: -2.5rem;
   left: 0;


### PR DESCRIPTION
As seen in this ticket (discovered on music) the pause/play button is misaligned on Safari. This pull request should get them lined up again.

**To test:**
1. Find or make an announcements flexslider and add the flexslider-numbered class to the View
2. Make sure the flexslider is set to autoplay by checking the Slideshow box admin/config/media/flexslider/list/announcemant_slider/edit 
3. Make sure the buttons are all aligned on safari and other browsers.

HINT: music has one

Small fix but nice to mop up small things when we can.