### PR TITLE
INTERIM-189 Adjusted sizing and spacing of images & figures in CKeditor

### DIFF
--- a/ckeditor.css
+++ b/ckeditor.css
@@ -81,11 +81,10 @@ a.link-button:hover {
 
 figure.image {
   display: table;
-  margin: 1rem;
+  margin: 0;
 }
 
 figure.image img {
-  max-width: 100%;
   display: block;
   margin: 0;
 }
@@ -110,9 +109,15 @@ figure.image br {
   display: none;
 }
 
-figure.image.floated-left { margin: 0.25rem 1rem 0.25rem 0; }
+figure.image.floated-left,
+.cke_widget_image[style*="float: left"] { 
+  margin: 0.25rem 1rem 0.25rem 0; 
+}
 
-figure.image.floated-right { margin: 0.25rem 0 0.25rem 1rem; }
+figure.image.floated-right,
+.cke_widget_image[style*="float: right"] { 
+  margin: 0.25rem 0 0.25rem 1rem; 
+}
 
 figure.image.floated-left img,
 figure.image.floated-right img { margin: 0; }


### PR DESCRIPTION
Right now there are two minor issues with images and figures in CKeditor.
1. Text closely hugs images and figures floated left and right in CKeditor.
2. Figures (images with captions) smush when put in a table cell.

These changes to the CKeditor CSS file are meant to add some default spacing around floated images and stop figures from smushing. 

Refer to the ticket for the expected outcome: https://isubit.atlassian.net/browse/INTERIM-189