### PR TITLE
INTERIM-190 External link icon refactor

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -281,28 +281,31 @@ a.link-button:hover {
     }
 
 /* --- External Links --- */
+/* .external class and .external-icon span provided by
+ * suitcase_external_links.js */
 
-/* Class provided by suitcase_external_links.js */
-.external {
+#section-content table .external {
   display: inline-flex;
 }
 
-/* Element provided in suitcase_external_links.js */
-.external-icon {
+#section-content .external-icon {
   display: inline-block;
-  font-size: 0.75rem;
+  font-size: 0.65rem;
   margin-left: 4px;
   vertical-align: text-top;
 }
 
 /* Exceptions */
 
-#section-content .pane-menu-menu-social .external-icon,
-#section-content .block-menu-social .external-icon,
-#section-content .view-resources .external-icon,
-#section-content .bibio-entry .external-icon,
-#section-content .flexslider .external-icon {
-    display: none;
+.pane-menu-menu-social .external-icon,
+.block-menu-social .external-icon,
+.view-resources .external-icon,
+.bibio-entry .external-icon,
+.flexslider .external-icon,
+.bean-hero .external-icon,
+.bean-card .external-icon,
+.bean-adventure .external-icon {
+    display: none !important;
 }
 
 /* -------------------- */

--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -282,29 +282,26 @@ a.link-button:hover {
 
 /* --- External Links --- */
 
-#section-content a.external:after {
-    content: '\f08e';
-    font-family: 'FontAwesome';
-    font-size: 0.75em;
-    display: inline-block;
-    width: 2rem;
-    margin-right: -2rem; /* Same as width. Helps prevent wrapping */
-    margin-left: 4px;
-    vertical-align: text-top;
+/* Class provided by suitcase_external_links.js */
+.external {
+  display: inline-flex;
 }
 
-#section-content a.external p {
-    display: inherit;
+/* Element provided in suitcase_external_links.js */
+.external-icon {
+  display: inline-block;
+  font-size: 0.75rem;
+  margin-left: 4px;
+  vertical-align: text-top;
 }
 
 /* Exceptions */
 
-#section-content .pane-menu-menu-social a.external:after,
-#section-content .block-menu-social a:after,
-#section-content .view-resources a.external:after,
-#section-content .bibio-entry a.external:after,
-#section-content .flex-caption a.external:after {
-    content: '';
+#section-content .pane-menu-menu-social .external-icon,
+#section-content .block-menu-social .external-icon,
+#section-content .view-resources .external-icon,
+#section-content .bibio-entry .external-icon,
+#section-content .flexslider .external-icon {
     display: none;
 }
 

--- a/js/suitcase_external_links.js
+++ b/js/suitcase_external_links.js
@@ -7,7 +7,7 @@
 
 	$(document).ready(function() {
 
-		$('a').filter(function() {
+		$('#section-content a').filter(function() {
 			return this.hostname && this.hostname !== location.hostname;
 		}).not('a:has(img)').addClass('external').append('<span class="external-icon"><span class="fa fa-external-link"></span></span>');
 

--- a/js/suitcase_external_links.js
+++ b/js/suitcase_external_links.js
@@ -9,7 +9,9 @@
 
 		$('a').filter(function() {
 			return this.hostname && this.hostname !== location.hostname;
-		}).not('a:has(img)').addClass('external');
+		}).not('a:has(img)').addClass('external').append('<span class="external-icon"><span class="fa fa-external-link"></span></span>');
+
+
 	});
 
 })(jQuery);


### PR DESCRIPTION
External links are tricky because they can occur in a variety of HTML structures. This branch should more comprehensively address them. The primary concern was that the icon would wrap to the next time on its own.

**To test:** 
Find ways to have an external link in multiple contexts.

These **should** have external link icons and they should look right and not be wrapping.

1. Link inline in text
2. Links in very narrow table columns. (You can dump a bunch of text in one column, and just a link in the second column.) 
3. Menu Cards with short link text and very long link text

These should **not** have external link icons.
1. Adventure Beans
2. Card Beans with and without an image
3. Hero Beans
4. Links in the site header and menu
5. Links in the footer
