### PR TITLE
INTERIM-192 Remove spacing around the expertise label on people nodes

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -2757,6 +2757,11 @@ td.multi-day .calendar.dayview a {
     clear: both;
 }
 
+.node-people .field-type-taxonomy-term-reference .field-label {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
 /* -------------------- */
 /* ## RESOURCES 
 /* -------------------- */


### PR DESCRIPTION
Refer to the ticket (https://isubit.atlassian.net/browse/INTERIM-192). On people profile pages, the alignment of the Expertise label is just slightly below its content. You can compare it to the correct alignment of the similarly styled education field. 

To test, pull down a site like ans that has people using expertise. Confirm that the alignment is correct. It's only a few pixels, so look close. 